### PR TITLE
Explicitly specify column typing

### DIFF
--- a/src/plots/plot_idmc.R
+++ b/src/plots/plot_idmc.R
@@ -17,8 +17,7 @@ plot_idmc <- function(
 
   # load in the data for plotting
   df_plot <- read_gs_file(
-    "wrangled_idmc",
-    col_types = "cccDdddddllllllllllldl"
+    "wrangled_idmc"
   ) %>%
     filter(
       iso3 == !!iso3

--- a/src/run.R
+++ b/src/run.R
@@ -146,8 +146,7 @@ pwalk(
 ##############################
 
 df_emailed <- read_gs_file(
-  name = "flags_emailed",
-  col_types = "ccccDDccccD"
+  name = "flags_emailed"
 ) %>%
   bind_rows(
     flags_email %>%

--- a/src/utils/google_sheets.R
+++ b/src/utils/google_sheets.R
@@ -1,5 +1,6 @@
 library(googlesheets4)
 library(googledrive)
+library(readr)
 
 # authorize drive access
 gs4_auth(
@@ -25,14 +26,54 @@ get_gs_file <- function(name) {
 # find the sheet by looking for file name
 # that has full stop (no .csv or other extension)
 # since Google extensions are not shown in the Drive API
-read_gs_file <- function(name, ...) {
+read_gs_file <- function(name, col_types = NULL, ...) {
   ss <- get_gs_file(paste0(name, "$"))
+  if (is.null(col_types)) {
+    col_types <- get_col_types(name)
+  }
   googlesheets4::read_sheet(
     ss = ss,
     sheet = name,
+    col_types = col_types,
     ...
   )
 }
+
+# since column types are set in stone
+# pass col_types explicitly to avoid silent errors due to col type
+# (i have seen some due to columns loading as POSIX rather than date )
+# also helps to catch if a sheet has been edited or changed without our knowledge
+get_col_types <- function(name) {
+  # flags files all the same
+  if (name %in% c("flags_idmc", "flags_cholera", "flags_total", "flags_test")) {
+    col_types <- "ccccDDccclc"
+  } else if (name == "flags_ipc") {
+    col_types <- "ccccDDDcclc"
+  } else if (name == "flags_total_daily") {
+    col_types <- "ccccDDDccclc"
+  } else if (name == "flags_emailed") {
+    col_types <- "ccccDDccccD"
+  } else if (name == "raw_idmc") {
+    col_types <- "dccddcccdDDDdcDDllllcccclD"
+  } else if (name == "raw_ipc") {
+    col_types <- "cccDccccDDdddddddddddddcc"
+  } else if (name == "raw_cholera") {
+    col_types <- "c"
+  } else if (name == "wrangled_idmc") {
+    col_types <- "cccDdddddllllllllllldl"
+  } else if (name == "wrangled_ipc") {
+    col_types <- "cccDcccccDDdddddddddddddccdddddddddl"
+  } else if (name == "wrangled_cholera") {
+    col_types <- "cDDd"
+  } else if (name %in% c("cerf_dashboard_names", "idmc_country_links")) {
+    col_types <- "cc"
+  } else if (name == "email_recipients") {
+    col_types <- "ccll"
+  } else {
+    NULL
+  }
+}
+
 
 # convenient file saver
 # find the sheet by looking for file name


### PR DESCRIPTION
Simple PR. Want to explicitly specify all the column typing when we load in Google Sheets for the system. Specifying them all in one location in case we load files in separate locations.