### PR TITLE
Fix start_dates for cholera

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+## December 11, 2023
+
+### Indicator: cholera
+
+- Adjusted start date parsing adjusted to address change in date format from
+`%d-%b-%y` to `%m/%d/%Y` in the WHO AFRO bulletins.
+
 ## October 3, 2023
 
 ### Email alerts

--- a/src/indicators/cholera/update_cholera.R
+++ b/src/indicators/cholera/update_cholera.R
@@ -54,7 +54,8 @@ df_cholera_wrangled <- df_cholera_raw |>
     ),
     date = as.Date(week_date),
     start_date = dplyr$case_when( # formats for start dates have switched in bulletins
-      stringr$str_detect(start_date_raw, "[A-Za-z]{3}") ~ lubridate$dmy(start_date_raw),
+      stringr$str_detect(start_date_raw, "[0-9]{1,2}[-|//][A-Za-z]{3}") ~ lubridate$dmy(start_date_raw),
+      stringr$str_detect(start_date_raw, "^[A-Za-z]{3}") ~ lubridate$mdy(start_date_raw),
       date >= "2023-09-25" ~ lubridate$mdy(start_date_raw),
       date < "2023-09-25" ~ lubridate$dmy(start_date_raw)
     ),

--- a/src/indicators/cholera/update_cholera.R
+++ b/src/indicators/cholera/update_cholera.R
@@ -47,15 +47,21 @@ df_cholera_wrangled <- df_cholera_raw |>
   dplyr$transmute(
     iso3 = countrycode$countryname(country, destination = "iso3c"),
     event,
-    start_date = lubridate$dmy(
-      dplyr$case_when(
-        !is.na(start_of_reporting_period) ~ start_of_reporting_period,
-        !is.na(start_of_reporting_period_2) ~ start_of_reporting_period_2,
-        !is.na(start_of_reporting_period_3) ~ start_of_reporting_period_3
-      )
+    start_date_raw = dplyr$case_when(
+      !is.na(start_of_reporting_period) ~ start_of_reporting_period,
+      !is.na(start_of_reporting_period_2) ~ start_of_reporting_period_2,
+      !is.na(start_of_reporting_period_3) ~ start_of_reporting_period_3
     ),
     date = as.Date(week_date),
+    start_date = dplyr$case_when( # formats for start dates have switched in bulletins
+      stringr$str_detect(start_date_raw, "[A-Za-z]{3}") ~ lubridate$dmy(start_date_raw),
+      date >= "2023-09-25" ~ lubridate$mdy(start_date_raw),
+      date < "2023-09-25" ~ lubridate$dmy(start_date_raw)
+    ),
     cholera_cases = readr$parse_number(total_cases)
+  ) |>
+  dplyr$select(
+    -start_date_raw
   ) |>
   dplyr$group_by( # some countries have multiple sets of cases reported each date (DRC)
     iso3,


### PR DESCRIPTION
Closes #37. Checks for 3 alphabetic characters in the date, and if they are present, parses using `dmy()`. If the date was prior to September 25, 2023, the parsing is still done as `dmy()` (since this is how those files have always been parsed. Then, otherwise, it parses as `mdy()`, which is the new format used by the WHO AFRO bulletins.